### PR TITLE
change showing all floats to luas build-in automatic nr format

### DIFF
--- a/scripts/additions/customDecks.lua
+++ b/scripts/additions/customDecks.lua
@@ -215,7 +215,7 @@ local deckInfo = {
 						add_round_eval_row{
 							dollars = back.effect.config.overkillDol,
 							bonus = true,
-							text = 'Overkill (' .. string.format("%.0f", (to_big(overkillAm) / to_big(G.GAME.cir_storeBlindReq)) * to_big(100)) .. '%)',
+              text = 'Overkill (' .. string.format("%g", (to_big(overkillAm) / to_big(G.GAME.cir_storeBlindReq)) * to_big(100)) .. '%)'
 							text_colour = CirnoMod.miscItems.colours.cirDM,
 							text_scale = 0.6,
 							name = 'custom',


### PR DESCRIPTION
uses %g flag which shows floating point numbers up to 5 significant digits (afaik,  honestly i forgot) instead if 0f% (which treated all digits of a float as significant and thus broke rendering in result screen)

also brings the number printing more in line with basegame balatro

tested locally with no crashes so far